### PR TITLE
Separate skill and wolfram ID from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,28 +15,19 @@ An example Alexa Skill to query Wolfram Alpha, written in Python.
    - You can follow the [official Amazon
      instructions](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/developing-an-alexa-skill-as-a-lambda-function)
      to give you a hand
-   - You **must** put your Wolfram Alpha AppID into the `ask_wolfram_alpha`
-     function, currently line 119
-   - You *should* uncomment the block in the `lambda_handler` function and
-     insert your `applicationId` to only allow requests coming from your
-     `applicationId`
+   - Put your Wolfram Alpha AppID into an environment variable called "WOLFRAM_ID" and also put your Alexa Skill Identifier in an environement variable called "SKILL_ID". For help view the [documentation](http://docs.aws.amazon.com/lambda/latest/dg/env_variables.html)
    - You can use `test_event.json` as your test template
    - Consider extending the timeout beyond the default of 3 seconds (I raised mine to 10, which is likely excessive, but eliminated some sporadic errors e.g. [#1](https://github.com/n8henrie/alexa-wolfram-alpha/issues/1))
 1. Create a new [Alexa
    Skill](https://developer.amazon.com/edw/home.html#/skill/create) using
    `intent_schema.json` and `sample_utterances.txt`
-1. **Don't publish** the skill (because it includes your personal Wolfram Alpha
-   API AppID), leave it in development mode
 1. Test that it's working from the web interface during the creation of the
    skill
 1. Test that it's working with your Echo
 
 ## Development
 
-Feel free to fork and hack on this, but keep in mind that the code in the repo
-shouldn't include your AppID. Unfortunately, it looks like there's no particularly simple way
-to set / get this kind of value from the AWS environment -- open an issue if
-I'm wrong about this.
+Feel free to fork and hack on this.
 
 The `setup.cfg` file is just in case you have a [homebrew](http://brew.sh/)
 installed python2 and want to include other 3rd party libraries in your code,

--- a/alexa-wolfram-alpha.py
+++ b/alexa-wolfram-alpha.py
@@ -8,6 +8,7 @@ http://amzn.to/1LGWsLG
 """
 
 from __future__ import print_function
+import os
 import xml.etree.ElementTree as etree
 try:
     from urllib.request import urlopen
@@ -30,9 +31,9 @@ def lambda_handler(event, context):
     prevent someone else from configuring a skill that sends requests to this
     function.
     """
-    # if (event['session']['application']['applicationId'] !=
-    #         "amzn1.echo-sdk-ams.app.[unique-value-here]"):
-    #     raise ValueError("Invalid Application ID")
+    if (event['session']['application']['applicationId'] !=
+            os.environ["SKILL_ID"]):
+        raise ValueError("Invalid Application ID")
 
     if event['session']['new']:
         on_session_started({'requestId': event['request']['requestId']},
@@ -116,7 +117,7 @@ def ask_wolfram_alpha(intent, session):
 
     api_root = "http://api.wolframalpha.com/v2/"
 
-    appid = ""
+    appid = os.environ["WOLFRAM_ID"]
 
     query = intent['slots']['response'].get('value')
     if query:


### PR DESCRIPTION
Let me know if the instructions and implementation are clear enough. I can make any changes you see as needed, but this should enhance the ease of setup as users won't have to mess with the actual code and can't accidentally submit their personal details to a public location.